### PR TITLE
Strip spaces in parsed file size string.

### DIFF
--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HDVinnie\MediaInfoHelper;
+namespace App\Helpers;
 
 class MediaInfo
 {
@@ -226,6 +226,7 @@ class MediaInfo
 
     private function parseFileSize($string)
     {
+        $string = str_replace(' ', '', $string);
         $number = (float)$string;
         preg_match("/[KMGTPEZ]/i", $string, $size);
         if (!empty($size[0])) {


### PR DESCRIPTION
The `parsedFileSize` function has a flaw for files that are over 1000MB. Since MediaInfo puts a space in between the 1 and the 0, the function will return a size of 1 MB in bytes since `parsedFileSize` doesn't compensate for that. 

I've added `$string = str_replace(' ', '', $string);` to remove all spaces from the parsed file size string to fix the problem.